### PR TITLE
Update podspec to use the code with tag 0.0.4

### DIFF
--- a/RCRunkeeperSwitch.podspec
+++ b/RCRunkeeperSwitch.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   s.author             = { "Chao Ruan" => "chaoruan818@gmail.com" }
   s.social_media_url   = "http://twitter.com/chaoruan"
   s.platform     = :ios, "7.0"
-  s.source       = { :git => "https://github.com/rcgary/RCRunkeeperSwitch.git", :tag => "0.0.1" }
+  s.source       = { :git => "https://github.com/rcgary/RCRunkeeperSwitch.git", :tag => "0.0.4" }
   s.source_files  = "RCRunkeeperSwitch/**/*.{h,m}"
   s.ios.frameworks = ['UIKit', 'Foundation']
   s.ios.deployment_target = '7.0'


### PR DESCRIPTION
Current podspec has version 0.0.4 but internally uses the code v0.0.1.
Switch to v0.0.4 in order to include the `selectedIndex` property.